### PR TITLE
[DEV1A-6041] - Code Merge for oneAPI-cli – 2025.1.0 Release

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -10,7 +10,7 @@ _____________________________________________________________________________
 
 BSD 3-Clause "New" or "Revised" License
 
-Copyright (C) Intel Corporation. All rights reserved.
+Copyright (C) 2019, Intel Corporation. All rights reserved.
 
 
 Redistribution and use in source and binary forms, with or without modification,

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/intel/oneapi-cli
 
-go 1.20
+go 1.24.1
 
 require (
 	github.com/gdamore/tcell v1.4.0

--- a/pkg/ui/cli.go
+++ b/pkg/ui/cli.go
@@ -126,8 +126,8 @@ func (cli *CLI) selectLang() {
 			continue
 		}
 		list.AddItem(k, "", start, func() {
-			i := list.GetCurrentItem() //List doesnt support a reference
-			cli.selectProject(cli.aggregator.GetLanguages()[i])
+			lang, _ := list.GetItemText(list.GetCurrentItem())
+			cli.selectProject(lang)
 		})
 		start++
 	}


### PR DESCRIPTION
**JIRA**: https://jira.devtools.intel.com/browse/DEV1A-6041
**Build Result**: Attached the executable file as the build is not enabled in GitHub Actions. Built it locally.
**Download Link**: [oneapi-cli.zip](https://github.com/user-attachments/files/19362956/oneapi-cli.zip)